### PR TITLE
fix: Bandit and Blitz `org`

### DIFF
--- a/operators/bandit/index.ts
+++ b/operators/bandit/index.ts
@@ -3,7 +3,7 @@ import { IOperator } from "~/types/operator"
 export const bandit: IOperator = {
   name: "Bandit",
   role: "Defender",
-  org: "GSG9",
+  org: "GSG 9",
   squad: "WOLFGUARD",
   ratings: {
     health: 1,

--- a/operators/blitz/index.ts
+++ b/operators/blitz/index.ts
@@ -3,7 +3,7 @@ import { IOperator } from "~/types/operator"
 export const blitz: IOperator = {
   name: "Blitz",
   role: "Attacker",
-  org: "GSG9",
+  org: "GSG 9",
   squad: "VIPERSTRIKE",
   ratings: {
     health: 2,


### PR DESCRIPTION
IQ and Jäger's org is `"GSG 9"` but Badit and Blitz's is `"GSG9"` (no space)