### PR TITLE
feat: add denari icon

### DIFF
--- a/operators/denari/denari.svg
+++ b/operators/denari/denari.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   x="0px"
+   y="0px"
+   width="350"
+   height="350"
+   viewBox="0 0 350 350"
+   xml:space="preserve"
+   id="svg13"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1" />
+	<g
+   id="background"
+   style="display:inline;opacity:1">
+		<rect
+   style="display:inline;opacity:0.4;fill:#0e0e0e;fill-opacity:1;stroke-width:15;stroke-linejoin:round"
+   id="rect13"
+   width="260"
+   height="260"
+   x="45"
+   y="45" /><path
+   style="display:none;fill:#c82127;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+   d="M 277.77769,249.39792 24.0798,307.01745 134.4054,241.4815 108.17561,225.57164 58.224965,254.11699 v -29.22886 l 27.384049,-15.81019 v -25.89946 l -13.242398,7.6455 V 101.04916 L 133.53825,84.658268 175,61.919485 193.71483,72.724498 325.0773,44.289631 236.45904,95.453407 263.00241,110.77823 290.25582,95.043473 v 26.215517 l -27.95746,16.14125 v 31.15836 l 15.75565,-9.09653 z"
+   id="path1" />
+		
+	</g>
+	<g
+   id="icon"
+   style="display:inline;fill:none;fill-opacity:1">
+		
+		
+		
+		
+		
+		
+	<path
+   id="path1-5"
+   style="display:inline;opacity:1;fill:#c82127;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+   d="M 325.07812,44.289062 193.71484,72.724609 175,61.919922 133.53906,84.658203 72.367188,101.04883 v 89.77539 l 13.242187,-7.64649 v 25.90039 l -27.384766,15.81055 v 29.22852 l 49.951171,-28.54492 26.23047,15.91015 -110.326172,65.53516 253.697262,-57.61914 0.27735,-89.93555 -15.75586,9.0957 v -31.1582 l 27.95703,-16.14062 V 95.042969 L 263.00195,110.77734 236.45898,95.453125 Z M 175,78.439453 V 120.4043 l 36.34375,-20.982425 v 41.964845 l 36.3418,-20.98242 v 41.96484 41.9668 l -36.3418,-20.98242 v 41.96484 L 175,204.33594 v 41.96484 l -36.34375,-20.98242 -36.3418,-20.98242 36.3418,-20.98242 -36.3418,-20.98438 36.3418,-20.98242 -36.3418,-20.98242 36.3418,-20.982425 z M 138.65625,99.421875 V 141.38672 L 175,120.4043 Z M 175,120.4043 v 41.96484 l 36.34375,-20.98242 z m 36.34375,20.98242 v 41.9668 l 36.3418,-20.98438 z m 0,41.9668 L 175,162.36914 v 41.9668 z M 175,204.33594 138.65625,183.35352 v 41.96484 z M 138.65625,183.35352 175,162.36914 138.65625,141.38672 Z" /><g
+   id="g6"
+   style="display:inline;fill:none;fill-opacity:1"><path
+     d="m 175,204.33594 v 41.96484 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#000000;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6" /><path
+     d="m 211.34375,183.35352 v 41.96484 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#000000;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7" /><path
+     d="m 174.99964,162.37004 v 41.96484 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#000000;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7-5" /><path
+     d="m 211.34263,141.3874 v 41.96484 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#000000;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7-4" /><path
+     d="m 138.657,99.422201 v 41.964839 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7-49" /><path
+     d="m 174.99964,120.40474 v 41.96484 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7-87" /><path
+     d="M 175.00001,78.439553 V 120.40439 L 211.34376,99.421973 Z"
+     style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7-7" /><path
+     d="m 211.34263,99.42197 v 41.96484 l 36.34375,-20.98242 z"
+     style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:6, 24"
+     id="path6-7-1" /></g></g>
+</svg>


### PR DESCRIPTION
In addition to PR #65 I created a first version of the denari icon, based on the offical ubisoft icon.

<img width="104" height="104" alt="r6s-operators-badge-denari" src="https://github.com/user-attachments/assets/434002bf-aad6-4a33-9c32-2168c63db369" />

@marcopixel I don't own illustrator, so it would be nice if you can format it like the other icons.

Thanks